### PR TITLE
Update gvsbuild stack and allow releases using both a newer stack, as well as using the latest versions that still support python 3.7.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,22 +4,37 @@ name: Release
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-    inputs:
-      ref:
-        description: "Enter a gvfsbuild tag or commit to release"
-        default: ""
+   inputs:
+     fork:
+       description: "Enter a gvsbuild fork for the build with the latest stack, defaults to wingtk."
+       default: "wingtk"
+     ref:
+       description: "Enter a git ref for checking out the above repository, defaults to main."
+       default: "main"
 
 jobs:
   build:
     runs-on: windows-2022
     strategy:
       matrix:
-        python: ["3.7", "3.9", "3.10"]
+        python: ["3.9", "3.10"]
         platform: [x64, win32]
         vstudio: [17]
-        exclude:
-          - python: ${{ github.event.inputs.ref == 'latest' && '3.7' }}
+        fork: ["${{ github.event.inputs.fork }}"]
+        ref: ["${{ github.event.inputs.ref }}"]
         include:
+          - python: "3.7"
+            platform: x64
+            arch: x64
+            vstudio: 17
+            fork: "Lord-Kamina"
+            ref: "older"
+          - python: "3.7"
+            platform: win32
+            arch: x86
+            vstudio: 17
+            fork: "Lord-Kamina"
+            ref: "older"
           - platform: x64
             arch: x64
           - platform: win32
@@ -29,9 +44,9 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
         with:
-          repository: Lord-Kamina/gvsbuild
+          repository: ${{ matrix.fork }}/gvsbuild
           fetch-depth: 0
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ matrix.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -72,12 +87,12 @@ jobs:
 
       - name: Current Date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ github.event.inputs.ref }}
-          tag_name: ${{ github.event.inputs.ref }}
+          name: release
+          tag_name: release-${{ steps.date.outputs.date }}
           body: gvsbuild-${{ steps.date.outputs.date }}
           files: "*.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,12 +87,13 @@ jobs:
 
       - name: Current Date
         id: date
+        shell: bash
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          name: release
-          tag_name: release-${{ steps.date.outputs.date }}
+          name: release-${{ steps.date.outputs.date }}
           body: gvsbuild-${{ steps.date.outputs.date }}
+          make_latest: true
           files: "*.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ on:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-2022
     strategy:
       matrix:
         python: ["3.9", "3.10"]
         platform: [x64, win32]
-        vstudio: [16]
+        vstudio: [17]
         include:
           - platform: x64
             arch: x64
@@ -25,14 +25,14 @@ jobs:
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           repository: wingtk/gvsbuild
           fetch-depth: 0
           ref: ${{ github.event.inputs.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.arch }}
@@ -52,11 +52,12 @@ jobs:
           gvsbuild build
           --platform=${{ matrix.arch }}
           --vs-ver=${{ matrix.vstudio }}
-          --same-python
           --enable-gi
           --py-wheel
-          --skip gtksourceview4,emeus,clutter
-          --patches-root-dir=${{ github.workspace }}\patches
+          --skip gtksourceview4
+          --skip emeus
+          --skip clutter
+          --patches-root-dir=${{ github.workspace }}\gvsbuild\patches
           gtk3-full pycairo pygobject lz4 enchant
 
       - name: Restore git binary
@@ -75,7 +76,7 @@ jobs:
         run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           name: latest
           tag_name: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,9 +91,13 @@ jobs:
         run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: ncipollo/release-action@v1
         with:
           name: release-${{ steps.date.outputs.date }}
+          commit: ${{ github.sha }}
+          tag: release-${{ steps.date.outputs.date }}
           body: gvsbuild-${{ steps.date.outputs.date }}
-          make_latest: true
-          files: "*.zip"
+          makeLatest: true
+          allowUpdates: true
+          replacesArtifacts: true
+          artifacts: "*.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,8 @@ jobs:
           --vs-ver=${{ matrix.vstudio }}
           --enable-gi
           --py-wheel
-          --skip gtksourceview4
-          --skip emeus
-          --skip clutter
           --patches-root-dir=${{ github.workspace }}\gvsbuild\patches
-          gtk3-full pycairo pygobject lz4 enchant
+          gtk3 pycairo pygobject wing lz4 enchant hicolor-icon-theme adwaita-icon-theme
 
       - name: Restore git binary
         run: Rename-Item  "C:\Program Files\Git\usr\notbin" bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,11 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        python: ["3.9", "3.10"]
+        python: ["3.7", "3.9", "3.10"]
         platform: [x64, win32]
         vstudio: [17]
+        exclude:
+          - python: ${{ github.event.inputs.ref == 'latest' && '3.7' }}
         include:
           - platform: x64
             arch: x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
         with:
-          repository: wingtk/gvsbuild
+          repository: Lord-Kamina/gvsbuild
           fetch-depth: 0
           ref: ${{ github.event.inputs.ref }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,12 +72,12 @@ jobs:
 
       - name: Current Date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> GITHUB_OUTPUT
 
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          name: latest
-          tag_name: latest
+          name: ${{ github.event.inputs.ref }}
+          tag_name: ${{ github.event.inputs.ref }}
           body: gvsbuild-${{ steps.date.outputs.date }}
           files: "*.zip"


### PR DESCRIPTION
This is preparatory work for some PRs I intend to send over at the deluge repo.
The end objective is to update the deluge CI/CD process, which itself is preparatory work for some actual improvements to deluge.