### PR TITLE
Fix glib win socket errors with patches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,21 @@ name: Release
 on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-   inputs:
-     fork:
-       description: "Enter a gvsbuild fork for the build with the latest stack, defaults to wingtk."
-       default: "wingtk"
-     ref:
-       description: "Enter a git ref for checking out the above repository, defaults to main."
-       default: "main"
+    inputs:
+      fork:
+        description: "Enter a gvsbuild fork for the build with the latest stack, defaults to wingtk."
+        default: "wingtk"
+      ref:
+        description: "Enter a git ref for checking out the above repository, defaults to main."
+        default: "main"
+      makeLatest:
+        description: "Mark this release as latest"
+        type: boolean
+        default: false
+      prerelease:
+        description: "Mark this release as pre-release (test/beta)"
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -20,8 +28,6 @@ jobs:
         python: ["3.10", "3.13"]
         platform: [x64]
         vstudio: [17]
-        fork: ["${{ github.event.inputs.fork }}"]
-        ref: ["${{ github.event.inputs.ref }}"]
       fail-fast: false
 
     steps:
@@ -33,9 +39,9 @@ jobs:
       # Checks-out gvsbuild repository
       - uses: actions/checkout@v4
         with:
-          repository: ${{ matrix.fork }}/gvsbuild
+          repository: ${{ github.event.inputs.fork }}/gvsbuild
           fetch-depth: 0
-          ref: ${{ matrix.ref }}
+          ref: ${{ github.event.inputs.ref }}
           path: gvsbuild
 
       # Apply glib patches
@@ -43,6 +49,13 @@ jobs:
         shell: pwsh
         run: |
           ${{ github.workspace }}\patches-repo\apply-glib-patches.ps1 -gvsbuildRoot "${{ github.workspace }}\gvsbuild"
+
+      # Get gvsbuild commit SHA for release naming
+      - name: Get gvsbuild commit
+        id: gvsbuild-commit
+        working-directory: gvsbuild
+        shell: bash
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -76,19 +89,17 @@ jobs:
         env:
           release_name: "gvsbuild-py${{ matrix.python }}-vs${{ matrix.vstudio }}-${{ matrix.platform }}"
 
-      - name: Current Date
-        id: date
-        shell: bash
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-
       - name: Release
         uses: ncipollo/release-action@v1
         with:
-          name: release-${{ steps.date.outputs.date }}
+          name: gvsbuild-${{ github.event.inputs.ref }}-${{ steps.gvsbuild-commit.outputs.sha }}
           commit: ${{ github.sha }}
-          tag: release-${{ steps.date.outputs.date }}
-          body: gvsbuild-${{ steps.date.outputs.date }}
-          makeLatest: true
+          tag: gvsbuild-${{ github.event.inputs.ref }}-${{ steps.gvsbuild-commit.outputs.sha }}
+          body: |
+            gvsbuild build from `${{ github.event.inputs.fork }}/gvsbuild@${{ github.event.inputs.ref }}`
+            gvsbuild commit: `${{ steps.gvsbuild-commit.outputs.sha }}`
+          makeLatest: ${{ github.event.inputs.makeLatest == 'true' }}
+          prerelease: ${{ github.event.inputs.prerelease == 'true' }}
           allowUpdates: true
           replacesArtifacts: true
           artifacts: "*.zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       # Check out this repo for patches
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           path: patches-repo
 
       # Checks-out gvsbuild repository
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.inputs.fork }}/gvsbuild
           fetch-depth: 0
@@ -58,7 +58,7 @@ jobs:
         run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,24 @@ jobs:
       fail-fast: false
 
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Check out this repo for patches
+      - uses: actions/checkout@v4
+        with:
+          path: patches-repo
+
+      # Checks-out gvsbuild repository
       - uses: actions/checkout@v4
         with:
           repository: ${{ matrix.fork }}/gvsbuild
           fetch-depth: 0
           ref: ${{ matrix.ref }}
+          path: gvsbuild
+
+      # Apply glib patches
+      - name: Apply glib patches
+        shell: pwsh
+        run: |
+          ${{ github.workspace }}\patches-repo\apply-glib-patches.ps1 -gvsbuildRoot "${{ github.workspace }}\gvsbuild"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -42,9 +54,11 @@ jobs:
         run: python -m pip install wheel build
 
       - name: Install gvsbuild tool
+        working-directory: gvsbuild
         run: python -m pip install .
 
       - name: Build
+        working-directory: gvsbuild
         run: >
           gvsbuild build
           --platform=${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          architecture: ${{ matrix.arch }}
+          architecture: ${{ matrix.platform }}
 
       - name: Install Build Deps
         run: python -m pip install wheel build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
-        platform: [x64,x86]
+        python: ["3.10", "3.13"]
+        platform: [x64]
         vstudio: [17]
         fork: ["${{ github.event.inputs.fork }}"]
         ref: ["${{ github.event.inputs.ref }}"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,8 @@ jobs:
           architecture: ${{ matrix.platform }}
 
       - name: Install Build Deps
-        run: python -m pip install wheel build
+        # Pin setuptools<81 to avoid breaking g-ir-scanner on Windows
+        run: python -m pip install "setuptools<81" wheel build
 
       - name: Install gvsbuild tool
         working-directory: gvsbuild

--- a/README.md
+++ b/README.md
@@ -1,6 +1,60 @@
 # Deluge gvsbuild Releases
 
-A repository to store [gvsbuild] Windows GTK 3 releases configured
-specifically for use with Deluge GTKUI.
+Builds custom [gvsbuild] Windows releases for the Deluge GTK UI, including Python bindings and patches as needed.
 
 [gvsbuild]: https://github.com/wingtk/gvsbuild
+
+## Overview
+
+This repository automates building gvsbuild releases with Deluge-specific configurations:
+
+- **Customizable patches**: Apply patches from `gvsbuild/patches/` during build
+- **Python versions**: See [workflow matrix](.github/workflows/release.yml) for current build targets
+- **Deluge stack**: GTK3, PyGObject, LZ4, Enchant, and Adwaita icons
+
+## Building Releases
+
+Releases are built automatically via GitHub Actions:
+
+1. Checks out this repo (for patches and configuration)
+2. Checks out [wingtk/gvsbuild]
+3. Applies any patches via [`apply-glib-patches.ps1`](apply-glib-patches.ps1)
+4. Builds gvsbuild with patches applied
+5. Creates release artifacts
+
+[wingtk/gvsbuild]: https://github.com/wingtk/gvsbuild
+
+### Manual Workflow Trigger
+
+Go to [Actions → Release](../../actions/workflows/release.yml) and click "Run workflow":
+
+- **fork**: gvsbuild fork to use (default: `wingtk`)
+- **ref**: git branch/tag to checkout (default: `main`)
+
+### Build Artifacts
+
+Each run produces release archives for the configured Python versions and platforms defined in the [workflow matrix](.github/workflows/release.yml).
+
+Artifacts are named: `gvsbuild-py{version}-vs{vstudio}-{platform}.zip`
+
+## Patches
+
+Patches are organized by project in `gvsbuild/patches/`:
+
+```
+gvsbuild/
+└── patches/
+    ├── glib/
+    │   ├── README.md
+    │   └── *.patch
+    └── [other-projects]/
+```
+
+See individual patch directories for details on what each patch does.
+
+## Adding Patches
+
+1. Create a branch for your patch work
+2. Add patches to `gvsbuild/patches/[project]/`
+3. The build workflow automatically applies and registers them
+4. Patch numbers must not conflict with existing patches in gvsbuild

--- a/apply-glib-patches.ps1
+++ b/apply-glib-patches.ps1
@@ -1,0 +1,141 @@
+# Apply glib patches to gvsbuild
+# Parses glib.py to check for numbering conflicts before copying patches
+#
+# Usage:
+#   apply-glib-patches.ps1 -gvsbuildRoot C:\path\to\gvsbuild
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$gvsbuildRoot
+)
+
+$ErrorActionPreference = "Stop"
+
+# Paths
+$patchSourceDir = "$PSScriptRoot\gvsbuild\patches\glib"
+$glibPy = "$gvsbuildRoot\gvsbuild\projects\glib.py"
+$patchDestDirGlib = "$gvsbuildRoot\gvsbuild\patches\glib"
+$patchDestDirGlibBase = "$gvsbuildRoot\gvsbuild\patches\glib-base"
+
+Write-Host "Applying glib patches to gvsbuild..." -ForegroundColor Cyan
+Write-Host ""
+
+# Validate source directory exists
+if (-not (Test-Path $patchSourceDir)) {
+    Write-Host "ERROR: Patch directory not found: $patchSourceDir" -ForegroundColor Red
+    exit 1
+}
+
+# Get patches to apply
+$patchesToApply = Get-ChildItem $patchSourceDir -Filter "*.patch" | Sort-Object Name
+
+if ($patchesToApply.Count -eq 0) {
+    Write-Host "No patches found in $patchSourceDir" -ForegroundColor Yellow
+    exit 0
+}
+
+Write-Host "Found $($patchesToApply.Count) patch(es) to apply:" -ForegroundColor Green
+foreach ($patch in $patchesToApply) {
+    Write-Host "  - $($patch.Name)"
+}
+Write-Host ""
+
+# Parse glib.py to find existing patches
+if (-not (Test-Path $glibPy)) {
+    Write-Host "ERROR: glib.py not found: $glibPy" -ForegroundColor Red
+    Write-Host "Ensure gvsbuild is checked out at: $gvsbuildRoot" -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "Checking for conflicts in glib.py..." -ForegroundColor Cyan
+
+$glibPyContent = Get-Content $glibPy -Raw
+$existingPatches = [regex]::Matches($glibPyContent, '"(\d{3}.*?\.patch)"') | ForEach-Object { $_.Groups[1].Value }
+
+Write-Host "Found $($existingPatches.Count) existing patch(es) in glib.py" -ForegroundColor Green
+Write-Host ""
+
+# Check for conflicts
+$conflicts = @()
+foreach ($patch in $patchesToApply) {
+    # Extract patch number (e.g., "003" from "003-fix-win-socket-errors.patch")
+    if ($patch.Name -match '^(\d{3})') {
+        $patchNumber = $matches[1]
+
+        # Check if this number exists in glib.py
+        foreach ($existing in $existingPatches) {
+            if ($existing -match "^$patchNumber") {
+                $conflicts += "Patch number conflict: $($patch.Name) conflicts with existing $existing"
+            }
+        }
+    }
+}
+
+if ($conflicts.Count -gt 0) {
+    Write-Host "ERROR: Patch numbering conflicts detected!" -ForegroundColor Red
+    Write-Host ""
+    foreach ($conflict in $conflicts) {
+        Write-Host "  [X] $conflict" -ForegroundColor Red
+    }
+    Write-Host ""
+    Write-Host "Please renumber patches to avoid conflicts." -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "No conflicts detected" -ForegroundColor Green
+Write-Host ""
+
+# Copy patches to both glib and glib-base directories
+Write-Host "Copying patches..." -ForegroundColor Cyan
+
+# Ensure directories exist
+if (-not (Test-Path $patchDestDirGlib)) {
+    New-Item -ItemType Directory -Path $patchDestDirGlib -Force | Out-Null
+}
+if (-not (Test-Path $patchDestDirGlibBase)) {
+    New-Item -ItemType Directory -Path $patchDestDirGlibBase -Force | Out-Null
+}
+
+foreach ($patch in $patchesToApply) {
+    # Copy to glib directory
+    $destPathGlib = Join-Path $patchDestDirGlib $patch.Name
+    Copy-Item $patch.FullName $destPathGlib -Force
+
+    # Copy to glib-base directory
+    $destPathGlibBase = Join-Path $patchDestDirGlibBase $patch.Name
+    Copy-Item $patch.FullName $destPathGlibBase -Force
+
+    Write-Host "  [OK] Copied $($patch.Name) to glib/ and glib-base/" -ForegroundColor Green
+}
+
+Write-Host ""
+
+# Register patches in glib.py
+Write-Host "Registering patches in glib.py..." -ForegroundColor Cyan
+
+$glibPyContent = Get-Content $glibPy -Raw
+
+foreach ($patch in $patchesToApply) {
+    # Check if already registered
+    if ($glibPyContent -match [regex]::Escape("`"$($patch.Name)`"")) {
+        Write-Host "  [SKIP] $($patch.Name) already registered" -ForegroundColor Yellow
+        continue
+    }
+
+    # Find last patch entry to insert after
+    $lastPatch = $existingPatches[-1]
+    $pattern = [regex]::Escape("`"$lastPatch`",")
+    $replacement = "`"$lastPatch`",`n                `"$($patch.Name)`","
+
+    # Replace all occurrences (for both GLibBase and GLib classes)
+    $glibPyContent = $glibPyContent -replace $pattern, $replacement
+
+    Write-Host "  [OK] Registered $($patch.Name)" -ForegroundColor Green
+}
+
+Set-Content $glibPy $glibPyContent -NoNewline
+
+Write-Host ""
+Write-Host "SUCCESS: All patches applied and registered" -ForegroundColor Green
+Write-Host ""
+exit 0

--- a/gvsbuild/patches/glib/003-fix-win-socket-errors.patch
+++ b/gvsbuild/patches/glib/003-fix-win-socket-errors.patch
@@ -1,0 +1,217 @@
+diff --git a/glib/giowin32.c b/glib/giowin32.c
+index ecc337a..619462d 100644
+--- a/glib/giowin32.c
++++ b/glib/giowin32.c
+@@ -157,6 +157,7 @@ struct _GIOWin32Channel {
+   /* Fields used by G_IO_WIN32_SOCKET channels */
+   int event_mask;
+   int last_events;
++  int last_close_error;      /* iErrorCode[FD_CLOSE_BIT] from WSAEnumNetworkEvents */
+   HANDLE event;
+   gboolean write_would_have_blocked;
+   gboolean ever_writable;
+@@ -284,6 +285,7 @@ g_io_channel_win32_init (GIOWin32Channel *channel)
+ 
+   channel->event_mask = 0;
+   channel->last_events = 0;
++  channel->last_close_error = 0;
+   channel->event = NULL;
+   channel->write_would_have_blocked = FALSE;
+   channel->ever_writable = FALSE;
+@@ -773,22 +775,46 @@ g_io_win32_prepare (GSource *source,
+ 		     channel->fd, (HANDLE) watch->pollfd.fd,
+ 		     event_mask_to_string (event_mask));
+ 	  if (WSAEventSelect (channel->fd, (HANDLE) watch->pollfd.fd,
+-			      event_mask) == SOCKET_ERROR)
+-	    if (channel->debug)
+-	      {
+-		gchar *emsg = g_win32_error_message (WSAGetLastError ());
++			      event_mask) != SOCKET_ERROR)
++	    channel->event_mask = event_mask;
++	  else if (channel->debug)
++	    {
++	      gchar *emsg = g_win32_error_message (WSAGetLastError ());
+ 
+-		g_print (" failed: %s", emsg);
+-		g_free (emsg);
+-	      }
+-	  channel->event_mask = event_mask;
++	      g_print (" failed: %s", emsg);
++	      g_free (emsg);
++	    }
+ 
+ 	  if (channel->debug)
+-	    g_print ("\n  setting last_events=0");
+-	  channel->last_events = 0;
++	    g_print ("\n  setting last_events=0%s",
++		     (channel->last_events & FD_CLOSE) ? " (preserving FD_CLOSE)" : "");
++	  channel->last_events = (channel->last_events & FD_CLOSE);
++
++	  /* FD_CLOSE is edge-triggered: if the peer closed while no
++	   * watch was active, the event was lost.  Probe with a zero-
++	   * byte recv(MSG_PEEK) to detect this.  If the socket has EOF
++	   * (returns 0), synthesise FD_CLOSE so check() delivers
++	   * G_IO_HUP.
++	   */
++	  if (!(channel->last_events & FD_CLOSE))
++	    {
++	      char dummy;
++	      int ret = recv (channel->fd, &dummy, 1, MSG_PEEK);
++
++	      if (channel->debug)
++		g_print ("\n  recv(MSG_PEEK) on sock=%d returned %d (err=%d)",
++			 channel->fd, ret, (ret == SOCKET_ERROR) ? WSAGetLastError () : 0);
++
++	      if (ret == 0)
++		{
++		  if (channel->debug)
++		    g_print (" -> synthesising FD_CLOSE");
++		  channel->last_events |= FD_CLOSE;
++		  WSASetEvent ((WSAEVENT) watch->pollfd.fd);
++		}
++	    }
+ 
+ 	  if ((event_mask & FD_WRITE) &&
+-	      channel->ever_writable &&
+ 	      !channel->write_would_have_blocked)
+ 	    {
+ 	      if (channel->debug)
+@@ -871,8 +897,9 @@ g_io_win32_check (GSource *source)
+       if (channel->last_events & FD_WRITE)
+ 	{
+ 	  if (channel->debug)
+-	    g_print (" sock=%d event=%p last_events has FD_WRITE",
+-		     channel->fd, (HANDLE) watch->pollfd.fd);
++	    g_print (" sock=%d event=%p last_events has FD_WRITE%s",
++		     channel->fd, (HANDLE) watch->pollfd.fd,
++		     (channel->last_events & FD_CLOSE) ? " (FD_CLOSE also in last_events!)" : "");
+ 	}
+       else
+ 	{
+@@ -886,9 +913,17 @@ g_io_win32_check (GSource *source)
+ 		     channel->fd, 
+ 		     event_mask_to_string (events.lNetworkEvents));
+ 	  
++	  if (events.lNetworkEvents & FD_CLOSE)
++	    {
++	      if (channel->debug)
++		g_print ("\n  FD_CLOSE received! iErrorCode[FD_CLOSE_BIT]=%d",
++			 events.iErrorCode[FD_CLOSE_BIT]);
++	    }
++
+ 	  if (watch->pollfd.revents != 0 &&
+ 	      events.lNetworkEvents == 0 &&
+-	      !(channel->event_mask & FD_WRITE))
++	      !(channel->event_mask & FD_WRITE) &&
++	      !(channel->last_events & FD_CLOSE))
+ 	    {
+ 	      channel->event_mask = 0;
+ 	      if (channel->debug)
+@@ -902,12 +937,43 @@ g_io_win32_check (GSource *source)
+ 	    }
+ 	  else if (events.lNetworkEvents & FD_WRITE)
+ 	    channel->ever_writable = TRUE;
+-	  channel->last_events = events.lNetworkEvents;
++	  else if (watch->pollfd.revents != 0 &&
++		   events.lNetworkEvents == 0 &&
++		   (channel->event_mask & FD_WRITE) &&
++		   !channel->ever_writable)
++	    {
++	      /* Event was manually set in prepare() via WSASetEvent() for a
++	       * newly registered write watch on an already-connected socket.
++	       * FD_WRITE won't fire because it's edge-triggered (only on
++	       * connect or after WSAEWOULDBLOCK recovery). Mark the socket
++	       * as writable and reset the event to prevent busy-looping.
++	       */
++	      channel->ever_writable = TRUE;
++	      ResetEvent ((HANDLE) watch->pollfd.fd);
++	    }
++	  /* Preserve FD_CLOSE across polls: it is edge-triggered and
++	   * WSAEnumNetworkEvents() only reports it once, but the
++	   * application needs G_IO_HUP on every subsequent check()
++	   * until the watch is removed. Also preserve the error code
++	   * from iErrorCode[FD_CLOSE_BIT] so we can distinguish
++	   * aborted connections from clean shutdowns.
++	   */
++	  if (events.lNetworkEvents & FD_CLOSE)
++	    channel->last_close_error = events.iErrorCode[FD_CLOSE_BIT];
++	  channel->last_events = events.lNetworkEvents
++	    | (channel->last_events & FD_CLOSE);
+ 	}
+ 
+       watch->pollfd.revents = 0;
+       if (channel->last_events & (FD_READ | FD_ACCEPT))
+ 	watch->pollfd.revents |= G_IO_IN;
++      /* On error conditions (aborted connection), also set G_IO_IN to allow
++       * the application to read from the socket and retrieve the error via
++       * recv(). This matches Linux poll() behavior where POLLIN is set on
++       * error conditions to allow error retrieval via read().
++       */
++      if (channel->last_close_error != 0)
++	watch->pollfd.revents |= G_IO_IN;
+ 
+       if (channel->last_events & FD_WRITE)
+ 	watch->pollfd.revents |= G_IO_OUT;
+@@ -921,10 +987,34 @@ g_io_win32_check (GSource *source)
+ 	      if (events.iErrorCode[FD_CONNECT_BIT] == 0)
+ 		watch->pollfd.revents |= G_IO_OUT;
+ 	      else
+-		watch->pollfd.revents |= (G_IO_HUP | G_IO_ERR);
++		{
++		  /* Connection error (refused, timeout, etc.) - set IN to
++		   * match Linux poll() behavior and allow error retrieval.
++		   */
++		  watch->pollfd.revents |= (G_IO_IN | G_IO_HUP | G_IO_ERR);
++		}
+ 	    }
+-	  if (watch->pollfd.revents == 0 && (channel->last_events & (FD_CLOSE)))
+-	    watch->pollfd.revents |= G_IO_HUP;
++	}
++
++      /* FD_CLOSE is edge-triggered: WSAEnumNetworkEvents() reports it
++       * only once.  Always map it to G_IO_HUP regardless of what other
++       * events (FD_READ, FD_WRITE) arrived in the same call, otherwise
++       * the application never learns the peer closed the connection.
++       *
++       * If iErrorCode[FD_CLOSE_BIT] indicates an error (WSAECONNRESET,
++       * WSAECONNABORTED, etc.), also set G_IO_ERR to distinguish aborted
++       * connections from clean shutdowns. This allows applications to
++       * properly differentiate between ConnectionDone and ConnectionLost.
++       */
++      if (channel->last_events & FD_CLOSE)
++	{
++	  if (channel->debug)
++	    g_print ("\n  FD_CLOSE(err=%d) -> G_IO_HUP%s",
++		     channel->last_close_error,
++		     channel->last_close_error ? "+G_IO_ERR" : "");
++	  watch->pollfd.revents |= G_IO_HUP;
++	  if (channel->last_close_error != 0)
++	    watch->pollfd.revents |= G_IO_ERR;
+ 	}
+ 
+       /* Regardless of WSAEnumNetworkEvents() result, if watching for
+@@ -1008,6 +1098,8 @@ g_io_win32_finalize (GSource *source)
+     case G_IO_WIN32_SOCKET:
+       if (channel->debug)
+ 	g_print (" SOCK sock=%d", channel->fd);
++      channel->event_mask = 0;
++      channel->last_close_error = 0;
+       break;
+ 
+     default:
+@@ -1602,6 +1694,15 @@ g_io_win32_sock_create_watch (GIOChannel    *channel,
+   if (win32_channel->event == 0)
+     win32_channel->event = WSACreateEvent ();
+ 
++  /* Reset event_mask to force WSAEventSelect to be re-called in prepare().
++   * Without this, re-registering a watch (source_remove + io_add_watch) would
++   * skip WSAEventSelect because the cached event_mask matches, even though the
++   * previous watch's event association may have been invalidated.
++   * See: https://gitlab.gnome.org/GNOME/glib/-/issues/214
++   */
++  win32_channel->event_mask = 0;
++  win32_channel->last_close_error = 0;
++
+   watch->pollfd.fd = (gintptr) win32_channel->event;
+   watch->pollfd.events = condition;
+   

--- a/gvsbuild/patches/glib/README.md
+++ b/gvsbuild/patches/glib/README.md
@@ -1,0 +1,24 @@
+# GLib Patches for Deluge
+
+This directory contains patches that are applied to GLib during the gvsbuild build process.
+
+## Patches
+
+### 003-fix-win-socket-errors.patch
+
+Fixes GLib's broken socket event delivery on Windows, which prevented Twisted's GI/GTK reactor from working reliably.
+
+**Problem:** GLib's Windows socket implementation (`glib/giowin32.c`) fails to deliver socket events after `source_remove`/`io_add_watch` cycles, causing 120+ second hangs waiting for write (OUT) events that never arrive.
+
+**Solution:** Reset `event_mask` in two places:
+1. `g_io_win32_sock_create_watch()` - Force fresh WSAEventSelect for new watches
+2. `g_io_win32_finalize()` - Clean state on channel close
+
+**References:**
+- [GLib GitLab #214](https://gitlab.gnome.org/GNOME/glib/-/issues/214) - Missing `WSAEventSelect` call
+- [GLib GitLab #40](https://gitlab.gnome.org/GNOME/glib/-/issues/40) - Async IO stalls
+- Development repo: [cas--/glib-win-errors](https://github.com/cas--/glib-win-errors)
+
+## Usage
+
+Patches are automatically applied by the `apply-glib-patches.ps1` script during the GitHub Actions build workflow.


### PR DESCRIPTION
Fixes GLib's broken socket event delivery on Windows, which prevented Twisted's GI/GTK reactor from working reliably.

Since the fixes are not yet upstream and we only need them for Windows packaging I have added a patch tooling so we can maintain them for now. 

**References:**
- [GLib GitLab #214](https://gitlab.gnome.org/GNOME/glib/-/issues/214) - Missing `WSAEventSelect` call
- [GLib GitLab #40](https://gitlab.gnome.org/GNOME/glib/-/issues/40) - Async IO stalls
- Development repo: https://github.com/cas--/glib-win-errors/